### PR TITLE
Recognized phrase available in Tasker

### DIFF
--- a/phone/src/com/RSen/Commandr/tasker/QueryReceiver.java
+++ b/phone/src/com/RSen/Commandr/tasker/QueryReceiver.java
@@ -66,6 +66,11 @@ public final class QueryReceiver extends BroadcastReceiver {
                         }
                     }
                     if (matchFound) {
+                        if ( TaskerPlugin.Condition.hostSupportsVariableReturn( intent.getExtras() ) ) {
+                            Bundle varsBundle = new Bundle();
+                            varsBundle.putString("%commandr_text", lastPhrase.trim());
+                            TaskerPlugin.addVariableBundle( getResultExtras( true ), varsBundle );
+                        }
                         setResultCode(LocaleIntent.RESULT_CONDITION_SATISFIED);
                     } else {
                         setResultCode(LocaleIntent.RESULT_CONDITION_UNSATISFIED);


### PR DESCRIPTION
Phrase that matched the condition is handed to Tasker as %commandr_text, as wanted in Issue RSenApps/Commandr-Android#2
